### PR TITLE
feat: Update vesting function, add ownership (SC-4718)

### DIFF
--- a/src/RevenueDistributionToken.sol
+++ b/src/RevenueDistributionToken.sol
@@ -31,7 +31,7 @@ contract RevenueDistributionToken is IRevenueDistributionToken, ERC20 {
     /*** Administrative Functions ***/
     /********************************/
 
-    function acceptOwner() external override {
+    function acceptOwnership() external override {
         require(msg.sender == pendingOwner, "RDT:AO:NOT_PO");
         owner        = msg.sender;
         pendingOwner = address(0);
@@ -42,14 +42,15 @@ contract RevenueDistributionToken is IRevenueDistributionToken, ERC20 {
         pendingOwner = pendingOwner_;
     }
 
-    function updateVestingSchedule(uint256 vestingPeriod_) external override {
+    // TODO: Revisit returns
+    function updateVestingSchedule(uint256 vestingPeriod_) external override returns (uint256 issuanceRate_, uint256 freeUnderlying_) {
         require(msg.sender == owner, "RDT:UVS:NOT_OWNER");
 
         // Update "y-intercept" to reflect current available underlying
-        uint256 _freeUnderlying = freeUnderlying = totalHoldings();
+        freeUnderlying = freeUnderlying_ = totalHoldings();
 
         // Calculate slope, update timestamp and period finish
-        issuanceRate        = (ERC20(underlying).balanceOf(address(this)) - _freeUnderlying) * RAY / vestingPeriod_;
+        issuanceRate        = issuanceRate_ = (ERC20(underlying).balanceOf(address(this)) - freeUnderlying_) * RAY / vestingPeriod_;
         lastUpdated         = block.timestamp;
         vestingPeriodFinish = block.timestamp + vestingPeriod_;
     }

--- a/src/interfaces/IRevenueDistributionToken.sol
+++ b/src/interfaces/IRevenueDistributionToken.sol
@@ -27,9 +27,9 @@ interface IRevenueDistributionToken {
     /*** Administrative Functions ***/
     /********************************/
 
-    function acceptOwner() external;
+    function acceptOwnership() external;
     function setPendingOwner(address pendingOwner_) external;
-    function updateVestingSchedule(uint256 vestingPeriod_) external;
+    function updateVestingSchedule(uint256 vestingPeriod_) external returns (uint256 issuanceRate_, uint256 freeUnderlying_);
 
     /************************/
     /*** Staker Functions ***/

--- a/src/test/RevenueDistributionToken.t.sol
+++ b/src/test/RevenueDistributionToken.t.sol
@@ -39,16 +39,16 @@ contract AuthTest is TestUtils {
         assertEq(rdToken.pendingOwner(), address(1));
     }
 
-    function test_acceptOwner_acl() external {
+    function test_acceptOwnership_acl() external {
         owner.rdToken_setPendingOwner(address(rdToken), address(notOwner));
 
         vm.expectRevert("RDT:AO:NOT_PO");
-        owner.rdToken_acceptOwner(address(rdToken));
+        owner.rdToken_acceptOwnership(address(rdToken));
 
         assertEq(rdToken.pendingOwner(), address(notOwner));
         assertEq(rdToken.owner(),        address(owner));
 
-        notOwner.rdToken_acceptOwner(address(rdToken));
+        notOwner.rdToken_acceptOwnership(address(rdToken));
 
         assertEq(rdToken.pendingOwner(), address(0));
         assertEq(rdToken.owner(),        address(notOwner));
@@ -194,9 +194,9 @@ contract RevenueStreamingTest is TestUtils {
         rdToken    = new RevenueDistributionToken("Revenue Distribution Token", "RDT", address(this), address(underlying));
     }
 
-    /*************************************/
+    /************************************/
     /*** Single updateVestingSchedule ***/
-    /*************************************/
+    /************************************/
 
     function test_updateVestingSchedule_single() external {
         assertEq(rdToken.freeUnderlying(),      0);
@@ -246,9 +246,9 @@ contract RevenueStreamingTest is TestUtils {
         assertEq(rdToken.totalHoldings(), 999);  // 999 < 1000
     }
 
-    /**************************************************/
+    /*************************************************/
     /*** Multiple updateVestingSchedule, same time ***/
-    /**************************************************/
+    /*************************************************/
 
     function test_updateVestingSchedule_sameTime_shorterVesting() external {
         _depositAndUpdateVesting(1000, 100 seconds);
@@ -298,9 +298,9 @@ contract RevenueStreamingTest is TestUtils {
         assertEq(rdToken.totalHoldings(), 2000);
     }
 
-    /********************************************************/
+    /*******************************************************/
     /*** Multiple updateVestingSchedule, different times ***/
-    /********************************************************/
+    /*******************************************************/
 
     function test_updateVestingSchedule_diffTime_shorterVesting() external {
         _depositAndUpdateVesting(1000, 100 seconds);  // 10 tokens per second

--- a/src/test/accounts/Owner.sol
+++ b/src/test/accounts/Owner.sol
@@ -5,8 +5,8 @@ import { IRevenueDistributionToken } from "../../interfaces/IRevenueDistribution
 
 contract Owner {
 
-    function rdToken_acceptOwner(address rdt_) external {
-        IRevenueDistributionToken(rdt_).acceptOwner();
+    function rdToken_acceptOwnership(address rdt_) external {
+        IRevenueDistributionToken(rdt_).acceptOwnership();
     }
 
     function rdToken_setPendingOwner(address rdt_, address pendingOwner_) external {


### PR DESCRIPTION
- Updated SPDX licenses
- Updated `depositVestingEarnings` to `updateVestingSchedule`
- Added admin functionality
- Updated interface and overrides

Moved from `depositVestingEarnings` to `updateVestingSchedule` because:
- It is simpler to reason about
- Allows an admin to recover from a previous bad input (1 million year vesting)