### PR TITLE
feat: MDL Audit Corrections (SC-4913)

### DIFF
--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -70,7 +70,7 @@ interface IERC4626 is IERC20 {
     /**
      *  @dev    Burns `shares_` from `owner_` and sends `assets_` to `receiver_`.
      *          MUST emit the {Withdraw} event.
-     *          MUST revert if all of the shares cannot be redeemed (due to insufficent shares, withdrawal limits, slippage, etc).
+     *          MUST revert if all of the shares cannot be redeemed (due to insufficient shares, withdrawal limits, slippage, etc).
      *  @param  shares_   The amount of shares to redeem.
      *  @param  receiver_ The receiver of the assets.
      *  @param  owner_    The owner of the shares.

--- a/contracts/interfaces/IRevenueDistributionToken.sol
+++ b/contracts/interfaces/IRevenueDistributionToken.sol
@@ -117,15 +117,16 @@ interface IRevenueDistributionToken is IERC4626, IERC20Permit {
 
     /**
      *  @dev    Does a ERC4626 `mint` with a ERC-2612 `permit`.
-     *  @param  shares_   The amount of `shares` to mint.
-     *  @param  receiver_ The receiver of the shares.
-     *  @param  deadline_ The timestamp after which the `permit` signature is no longer valid.
-     *  @param  v_        ECDSA signature v component.
-     *  @param  r_        ECDSA signature r component.
-     *  @param  s_        ECDSA signature s component.
-     *  @return assets_   The amount of shares deposited.
+     *  @param  shares_    The amount of `shares` to mint.
+     *  @param  receiver_  The receiver of the shares.
+     *  @param  maxAssets_ The maximum amount of assets that can be taken, as per the permit.
+     *  @param  deadline_  The timestamp after which the `permit` signature is no longer valid.
+     *  @param  v_         ECDSA signature v component.
+     *  @param  r_         ECDSA signature r component.
+     *  @param  s_         ECDSA signature s component.
+     *  @return assets_    The amount of shares deposited.
      */
-    function mintWithPermit(uint256 shares_, address receiver_, uint256 deadline_, uint8 v_, bytes32 r_, bytes32 s_) external returns (uint256 assets_);
+    function mintWithPermit(uint256 shares_, address receiver_, uint256 maxAssets_, uint256 deadline_, uint8 v_, bytes32 r_, bytes32 s_) external returns (uint256 assets_);
 
 
     /**********************/

--- a/contracts/test/Invariants.t.sol
+++ b/contracts/test/Invariants.t.sol
@@ -53,10 +53,10 @@ contract RDTInvariants is TestUtils, InvariantTest {
         // Performs random redeem calls from a random instantiated staker
         addTargetContract(address(stakerManager));
 
-        // Peforms random warps forward in time
+        // Performs random warps forward in time
         addTargetContract(address(warper));
 
-        // Create one staker to prevent underflows on index calculations
+        // Create one staker to prevent underflow on index calculations
         stakerManager.createStaker();
     }
 

--- a/contracts/test/RDTGetters.t.sol
+++ b/contracts/test/RDTGetters.t.sol
@@ -146,7 +146,7 @@ contract PreviewViewFunctionTest is TestUtils {
 
 }
 
-// TODO: test "vanilla" mint (whitout permit) --Done
+// TODO: test "vanilla" mint (without permit) --Done
 
 // TODO: mint with zero shares amt --Done
 
@@ -160,11 +160,11 @@ contract PreviewViewFunctionTest is TestUtils {
 
 // TODO: test convert to shares --DONE
 
-// TODO: testmax deposit --DONE
+// TODO: test max deposit --DONE
 
 // TODO: test max mint --DONE
 
-// TODO: test max Redem --DONE
+// TODO: test max redeem --DONE
 
 // TODO: test preview Deposit --DONE
 


### PR DESCRIPTION
- Alignment and whitespace
- Line breaks between unrelated or unaligned lines
- Various inline assignments of variables
- Common internal `_mint` function used by deposit and mint external functions
- Common internal `_burn` function used by redeem and withdraw functions
- Use preview functions once in external functions to determine assets/shares before passing both to the internal function, where they are used without any further conversions
- `mintWithPermit` permit is on a max amount of assets, so that the conversion from shares to assets does not result in an invalid permit if the rate changes, and so the only requirement is that the compute asset is less than or equal to the max amount permitted
- Bracketing math to make order of operations explicit
- Updated preview function comments with standardized explanation
- `_mulDivRoundUp` refactored into a `_divRoundUp` since the multiplication can be handled by the caller, and so that the function can hav a smaller scope (i.e. dividing and rounding up)
- `_divRoundUp` logic improved to simply round up of the division has a remainder
- Early conditional exit pattern in `_reduceCallerAllowance`
- Fixed typos
- Cleaned up `mintWithPermit` and `depositWithPermit` tests
- Some `mintWithPermit` tests were actually testing `depositWithPermit`, so that was fixed