### PR TITLE
fix: Remove APR function, fix --match-path

### DIFF
--- a/contracts/RevenueDistributionToken.sol
+++ b/contracts/RevenueDistributionToken.sol
@@ -190,10 +190,6 @@ contract RevenueDistributionToken is IRevenueDistributionToken, ERC20 {
     /*** View Functions ***/
     /**********************/
 
-    function APR() external view virtual override returns (uint256 apr_) {
-        return (issuanceRate * 365 days * 1e6) / (totalSupply * precision);
-    }
-
     function balanceOfAssets(address account_) public view virtual override returns (uint256 balanceOfAssets_) {
         return convertToAssets(balanceOf[account_]);
     }
@@ -258,11 +254,11 @@ contract RevenueDistributionToken is IRevenueDistributionToken, ERC20 {
 
     function totalAssets() public view virtual override returns (uint256 totalManagedAssets_) {
         uint256 issuanceRate_ = issuanceRate;
-        
+
         if (issuanceRate_ == 0) return freeAssets;
 
         uint256 vestingPeriodFinish_ = vestingPeriodFinish;
-        uint256 lastUpdated_         = lastUpdated; 
+        uint256 lastUpdated_         = lastUpdated;
 
         uint256 vestingTimePassed =
             block.timestamp > vestingPeriodFinish_ ?

--- a/contracts/interfaces/IRevenueDistributionToken.sol
+++ b/contracts/interfaces/IRevenueDistributionToken.sol
@@ -135,11 +135,6 @@ interface IRevenueDistributionToken is IERC20, IERC4626 {
     /**********************/
 
     /**
-     *  @dev Returns the annualized yearly return of the current vesting schedule.
-     */
-    function APR() external view returns (uint256 apr_);
-
-    /**
      *  @dev    Returns the amount of underlying assets owned by the specified account.
      *  @param  account_ Address of the account.
      *  @return assets_  Amount of assets owned.

--- a/test.sh
+++ b/test.sh
@@ -15,7 +15,7 @@ echo Using profile: $FOUNDRY_PROFILE
 
 if [ -z "$test" ];
 then
-    forge test --match-path "$PWD/contracts/test/*";
+    forge test --match-path "contracts/test/*";
 else
     forge test --match "$test";
 fi


### PR DESCRIPTION
Remove the APR function from RDT since it was using `totalSupply` in the denominator so the units were `MPL/(year * xMPL)` not `MPL/(year * MPL)`. It was decided that since this function is not used onchain that it should be removed.