### PR TITLE
feat: Drop fuzz runs to 30k

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -14,4 +14,4 @@ fuzz_runs = 100
 fuzz_runs = 500
 
 [super_deep]
-fuzz_runs = 50000
+fuzz_runs = 30000


### PR DESCRIPTION
- 50_000 was taking too long, dropping to prevent timeout failures